### PR TITLE
enh(dispaly): use new centreonGraphNg.class.php

### DIFF
--- a/graph-monitoring/src/generateGraph.php
+++ b/graph-monitoring/src/generateGraph.php
@@ -48,7 +48,7 @@ require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonService.class.php';
 require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';
-require_once $centreon_path . 'www/class/centreonGraph.class.php';
+require_once $centreon_path . 'www/class/centreonGraphNg.class.php';
 
 CentreonSession::start(1);
 


### PR DESCRIPTION
Only for 19.10.x

Based on https://github.com/centreon/centreon/tree/MON-3477-improve-chart-performance