### PR TITLE
fix(widget):Sanitize WidgetId, AutoRefresh and ACL DB Query

### DIFF
--- a/graph-monitoring/index.php
+++ b/graph-monitoring/index.php
@@ -72,7 +72,7 @@ try {
     
     $autoRefresh = filter_var($preferences['refresh_interval'], FILTER_VALIDATE_INT);
 
-    if ($autoRefresh === false || $autoRefresh < 5){
+    if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
     }
 
@@ -104,9 +104,9 @@ if (isset($tab[0]) && isset($tab[1]) && $centreon->user->admin == 0) {
         AND group_id IN (:groupList)";
 
     $res = $dbAcl->prepare($sql);
-    $res->bindValue(':hostId',$tab[0],PDO::PARAM_INT);
-    $res->bindValue(':serviceId',$tab[1],PDO::PARAM_INT);
-    $res->bindValue(':groupList',$grouplistStr,PDO::PARAM_STR);
+    $res->bindValue(':hostId', $tab[0], PDO::PARAM_INT);
+    $res->bindValue(':serviceId', $tab[1], PDO::PARAM_INT);
+    $res->bindValue(':groupList', $grouplistStr, PDO::PARAM_STR);
     $res->execute();
 
     if (!$res->rowCount()) {

--- a/graph-monitoring/index.php
+++ b/graph-monitoring/index.php
@@ -52,10 +52,16 @@ if (!CentreonSession::checkSession(session_id(), $pearDB)) {
 if (!isset($_REQUEST['widgetId'])) {
     exit;
 }
+
 $centreon = $_SESSION['centreon'];
-$widgetId = $_REQUEST['widgetId'];
+$widgetId = filter_var($_REQUEST['widgetId'], FILTER_VALIDATE_INT);
+
 
 try {
+    if ($widgetId === false) {
+        throw new InvalidArgumentException('Widget ID must be an integer');
+    }
+
     global $pearDB;
 
     $pearDB = $dbAcl = $db = $dependencyInjector['configuration_db'];
@@ -63,11 +69,13 @@ try {
 
     $widgetObj = new CentreonWidget($centreon, $db);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
-    $autoRefresh = 0;
+    
+    $autoRefresh = filter_var($preferences['refresh_interval'], FILTER_VALIDATE_INT);
 
-    if (isset($preferences['refresh_interval'])) {
-        $autoRefresh = $preferences['refresh_interval'];
+    if ($autoRefresh === false || $autoRefresh < 5){
+        $autoRefresh = 30;
     }
+
 } catch (Exception $e) {
     echo $e->getMessage() . "<br/>";
     exit;
@@ -89,13 +97,18 @@ $template = initSmartyTplForPopup($path, $template, "/", $centreon_path);
 
 $acl = 1;
 if (isset($tab[0]) && isset($tab[1]) && $centreon->user->admin == 0) {
-    $res = $dbAcl->query(
-        "SELECT host_id
+    $sql = "SELECT host_id
         FROM centreon_acl
-        WHERE host_id = " . $dbAcl->escape($tab[0]) . "
-            AND service_id = " . $dbAcl->escape($tab[1]) . "
-            AND group_id IN (" . $grouplistStr . ")"
-    );
+        WHERE host_id = :hostId
+        AND service_id = :serviceId
+        AND group_id IN (:groupList)";
+
+    $res = $dbAcl->prepare($sql);
+    $res->bindValue(':hostId',$tab[0],PDO::PARAM_INT);
+    $res->bindValue(':serviceId',$tab[1],PDO::PARAM_INT);
+    $res->bindValue(':groupList',$grouplistStr,PDO::PARAM_STR);
+    $res->execute();
+
     if (!$res->rowCount()) {
         $acl = 0;
     }
@@ -113,7 +126,6 @@ if ($acl === 0) {
         "auto;width:350px;'>" . _("Please select a graph period") . "</div>";
 }
 
-$autoRefresh = $preferences['refresh_interval'];
 $template->assign('widgetId', $widgetId);
 $template->assign('preferences', $preferences);
 $template->assign('interval', $preferences['graph_period']);

--- a/graph-monitoring/index.php
+++ b/graph-monitoring/index.php
@@ -56,7 +56,6 @@ if (!isset($_REQUEST['widgetId'])) {
 $centreon = $_SESSION['centreon'];
 $widgetId = filter_var($_REQUEST['widgetId'], FILTER_VALIDATE_INT);
 
-
 try {
     if ($widgetId === false) {
         throw new InvalidArgumentException('Widget ID must be an integer');


### PR DESCRIPTION
## Description

Fix a security breach were arguments passed through a request weren't sanitize.
Sanitize the preferences Form data.
Secure SQL request with PDO prepare/bind/exec

**Fixes**  MON-4960

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)