### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/graph-monitoring/configs.xml
+++ b/graph-monitoring/configs.xml
@@ -4,7 +4,7 @@
         <email>contact@centreon.com</email>
         <website>http://www.centreon.com</website>
         <description>This graph widget displays the evolution of metrics over time. It is possible to select the time window.</description>
-        <version>21.10.0-beta.1</version>
+        <version>21.10.0</version>
         <keywords>centreon, widget, rrd, monitoring</keywords>
         <screenshot></screenshot>
         <thumbnail>./widgets/graph-monitoring/resources/centreon-logo.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix